### PR TITLE
SLT-1040: Update default nginx version to 1.26.

### DIFF
--- a/silta/nginx.Dockerfile
+++ b/silta/nginx.Dockerfile
@@ -1,4 +1,4 @@
 # Dockerfile for building nginx.
-FROM wunderio/silta-nginx:1.17-v1
+FROM wunderio/silta-nginx:1.26-v1
 
 COPY . /app/web


### PR DESCRIPTION
### !! Blocked by https://github.com/wunderio/silta-images/pull/214 !!

Link to ticket: https://wunder.atlassian.net/browse/SLT-1040

Proposed changes:
- Update default nginx version to 1.26