### PR TITLE
Update silta-nginx to version 1.28

### DIFF
--- a/silta/nginx.Dockerfile
+++ b/silta/nginx.Dockerfile
@@ -1,4 +1,4 @@
 # Dockerfile for building nginx.
-FROM wunderio/silta-nginx:1.26-v1
+FROM wunderio/silta-nginx:1.28-v1
 
 COPY . /app/web


### PR DESCRIPTION
This PR aims to replace the usage of deprecated silta-nginx versions with the latest stable version 1.28.
 
Please review adjusted image tags and make sure this PR only changes relevant configuration files.

Also, do test that any custom nginx configurations are still working as expected, as there might be breaking changes between versions.

This pull request was created with https://github.com/wunderio/internal-mass-updater.